### PR TITLE
Fix building with current Haskell Platform (2014.2.0.0)

### DIFF
--- a/chess-server.cabal
+++ b/chess-server.cabal
@@ -20,6 +20,6 @@ executable chess-server
   main-is:             ChessBackend.hs
   -- other-modules:       
   other-extensions:    LambdaCase, QuasiQuotes, TemplateHaskell, TupleSections, NoMonomorphismRestriction, OverloadedStrings
-  build-depends:       base >=4.6 && <4.7, array >=0.4 && <0.5, th-printf >=0.3 && <0.4, aeson >=0.7 && <0.8, bytestring >=0.10 && <0.11, http-types >=0.8 && <0.9, wai >=3.0 && <3.1, warp >=3.0 && <3.1, wai-websockets >=3.0 && <3.1, websockets >=0.9 && <0.10, template-haskell >=2.8 && <2.9
+  build-depends:       base >=4.6 && <4.8, array >=0.4 && <0.6, th-printf >=0.3 && <0.4, aeson >=0.7 && <0.8, bytestring >=0.10 && <0.11, http-types >=0.8 && <0.9, wai >=3.0 && <3.1, warp >=3.0 && <3.1, wai-websockets >=3.0 && <3.1, websockets >=0.9 && <0.10, template-haskell >=2.8 && <2.10
   hs-source-dirs:      server
   default-language:    Haskell98


### PR DESCRIPTION
According to https://www.haskell.org/platform/changelog.html the latest
Haskell Platform (2014.2.0.0) ships with newer versions of a few
packages we need. Let's bump our upper bounds accordingly. In
particular, we need to bump the upper bounds of base, array and
template-haskell.

No actual code changes seem to be required.
